### PR TITLE
Add build dependency via pyproject.toml; remove setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[metadata]
-description-file = README.md
-
-[egg_info]
-tag_build = 
-tag_date = 0
-


### PR DESCRIPTION
`cython` and `numpy` are added to `pyproject.toml` so that they are installed before `setup.py` is read.

`setup.cfg` contains only duplicate information or empty settings so is removed.

---

It might be worthwhile to test the changes on test-pypi first before releasing to pypi.

```console
python setup.py sdist bdist_wheel
twine upload --repository-url https://test.pypi.org/legacy/ dist/*
pip install --index-url https://test.pypi.org/simple/ seislib
```