### PR TITLE
fix: api change in scipy.signal.tukey

### DIFF
--- a/docs/source/_build/html/_sources/modules/seislib.eq_tsm.rst.txt
+++ b/docs/source/_build/html/_sources/modules/seislib.eq_tsm.rst.txt
@@ -190,7 +190,7 @@ Defines the taper used for tapering the seismograms
 
 	**data_size** (``int``): Length of the data, which corresponds to the final size of the taper
 
-	**taper_type** (``func``): Taper function. Default is `scipy.signal.tukey <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
+	**taper_type** (``func``): Taper function. Default is `scipy.signal.windows.tukey <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
 
 	**alpha** (``float``): Shape parameter of the taper window.
 

--- a/docs/source/_build/html/modules/seislib.eq_tsm.html
+++ b/docs/source/_build/html/modules/seislib.eq_tsm.html
@@ -229,7 +229,7 @@ period, used to isolate the fundamental mode in the seismogram. It is a function
 <div><p><strong>center_idx</strong> (<code class="docutils literal notranslate"><span class="pre">int</span></code>): Index of corresponding to the center of the taper</p>
 <p><strong>taper_size</strong> (<code class="docutils literal notranslate"><span class="pre">int</span></code>): Lenght of the taper. The taper will be centred onto <cite>taper_idx</cite> and extend around the center by taper_size/2</p>
 <p><strong>data_size</strong> (<code class="docutils literal notranslate"><span class="pre">int</span></code>): Length of the data, which corresponds to the final size of the taper</p>
-<p><strong>taper_type</strong> (<code class="docutils literal notranslate"><span class="pre">func</span></code>): Taper function. Default is <a class="reference external" href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html">scipy.signal.tukey</a></p>
+<p><strong>taper_type</strong> (<code class="docutils literal notranslate"><span class="pre">func</span></code>): Taper function. Default is <a class="reference external" href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html">scipy.signal.windows.tukey</a></p>
 <p><strong>alpha</strong> (<code class="docutils literal notranslate"><span class="pre">float</span></code>): Shape parameter of the taper window.</p>
 </div></blockquote>
 <p><strong>Returns</strong></p>

--- a/docs/source/_build/html/seislib.eq_tsm.html
+++ b/docs/source/_build/html/seislib.eq_tsm.html
@@ -226,7 +226,7 @@ period, used to isolate the fundamental mode in the seismogram. It is a function
 <div><p><strong>center_idx</strong> (<code class="docutils literal notranslate"><span class="pre">int</span></code>): Index of corresponding to the center of the taper</p>
 <p><strong>taper_size</strong> (<code class="docutils literal notranslate"><span class="pre">int</span></code>): Lenght of the taper. The taper will be centred onto <cite>taper_idx</cite> and extend around the center by taper_size/2</p>
 <p><strong>data_size</strong> (<code class="docutils literal notranslate"><span class="pre">int</span></code>): Length of the data, which corresponds to the final size of the taper</p>
-<p><strong>taper_type</strong> (<code class="docutils literal notranslate"><span class="pre">func</span></code>): Taper function. Default is <a class="reference external" href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html">scipy.signal.tukey</a></p>
+<p><strong>taper_type</strong> (<code class="docutils literal notranslate"><span class="pre">func</span></code>): Taper function. Default is <a class="reference external" href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html">scipy.signal.windows.tukey</a></p>
 <p><strong>alpha</strong> (<code class="docutils literal notranslate"><span class="pre">float</span></code>): Shape parameter of the taper window.</p>
 </div></blockquote>
 <p><strong>Returns</strong></p>

--- a/seislib/eq/_eq_velocity.py
+++ b/seislib/eq/_eq_velocity.py
@@ -1440,7 +1440,7 @@ class TwoStationMethod:
             taper
             
         taper_type : func
-            Taper function. Default is `scipy.signal.tukey 
+            Taper function. Default is `scipy.signal.windows.tukey 
             <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.tukey.html>`_
             
         alpha : float 

--- a/seislib/eq/_eq_velocity.py
+++ b/seislib/eq/_eq_velocity.py
@@ -1423,7 +1423,7 @@ class TwoStationMethod:
     
     
     def build_taper(self, center_idx, taper_size, data_size, 
-                    taper_type=signal.tukey, alpha=0.1):
+                    taper_type=signal.windows.tukey, alpha=0.1):
         """ Defines the taper used for tapering the seismograms
         
         Parameters


### PR DESCRIPTION
Hi Fabrizio,

Scipy silently deprecated `scipy.signal.tukey` and now we have to use `scipy.signal.windows.tukey`.

I can also confirm `scipy.signal.windows.tukey` has existed since `scipy v1.9`, for (roughly?) as long as `scipy.signal.tukey`'s existence. So there's no drawback of this pull request.

Cheers,
Jiawen