### PR TITLE
MacOS pip install

### DIFF
--- a/seislib/tomography/_ray_theory/setup_all.py
+++ b/seislib/tomography/_ray_theory/setup_all.py
@@ -28,10 +28,9 @@ import platform
 names = ['_math', '_spherical_geometry', '_tomography']
 sources = ['%s.pyx'%name for name in names]
 extra_compile_args = ["-O3", "-ffast-math", "-march=native", "-fopenmp" ]
+extra_link_args=['-fopenmp']
 
 platform_name = platform.system()
-
-
 if platform_name.lower() == 'darwin':
     src_paths = ['/usr/local', '/opt/homebrew']
     for src in src_paths:
@@ -44,11 +43,6 @@ if platform_name.lower() == 'darwin':
         path = os.path.join(gcc_path, '%s/lib/gcc/%s'%(version, version_int))
         os.environ['CC'] = 'gcc-%s'%version_int
         os.environ['CXX'] = 'g++-%s'%version_int
-        extra_link_args=['-Wl,-rpath,%s'%path]
-        
-
-else:
-    extra_link_args=['-fopenmp']
 
 
 for name, source in zip(names, sources):

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ def setup_cython_extension():
             extra_link_args=['-Wl,-rpath,%s'%path]
     else:
         extra_link_args=['-fopenmp']
+
     ext_modules = []
     for name, source in zip(names, sources):
         language = 'c++' if name!='_math' else None

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ def setup_cython_extension():
     names = ['_math', '_spherical_geometry', '_tomography']
     sources = ['%s.pyx'%name for name in names]
     extra_compile_args = ["-O3", "-ffast-math", "-march=native", "-fopenmp"]
+    extra_link_args=['-fopenmp']
     platform_name = platform.system()
     if platform_name.lower() == 'darwin':
         src_paths = ['/usr/local', '/opt/homebrew']
@@ -67,9 +68,6 @@ def setup_cython_extension():
             path = os.path.join(gcc_path, '%s/lib/gcc/%s'%(version, version_int))
             os.environ['CC'] = 'gcc-%s'%version_int
             os.environ['CXX'] = 'g++-%s'%version_int
-            extra_link_args=['-Wl,-rpath,%s'%path]
-    else:
-        extra_link_args=['-fopenmp']
 
     ext_modules = []
     for name, source in zip(names, sources):


### PR DESCRIPTION
When running `pip install .` in a `pyenv` environment (no `conda`) on `macos` there was a linker issue with `openmp`.  `seislib` could still be installed but would fail when imported.

Solution: pass `-fopenmp` to linker in `cython`.

This should solve some downstream `cofi` issues.