### PR TITLE
Adding default return value to _ipixel_index

### DIFF
--- a/seislib/tomography/_ray_theory/_tomography.pyx
+++ b/seislib/tomography/_ray_theory/_tomography.pyx
@@ -99,6 +99,7 @@ cpdef ssize_t _pixel_index(double lat, double lon, double[:, ::1] mesh,
         if mesh[ipixel, 0] <= lat < mesh[ipixel, 1]: #parallel1<=lat<parallel2
             if mesh[ipixel, 2] <= lon < mesh[ipixel, 3]: #meridian1<=lon<meridian2
                 return ipixel
+    return -1
      
 
 @boundscheck(False)


### PR DESCRIPTION
The function `_ipixel_index` from `seislib.tomography._ray_theory._tomography` determines in which pixel a pair of coordinates `(lat, lon)` finds itself. It loops over all the pixel indices of the mesh and try to determine whether the coordinates are indeed in the pixel, and promptly returns the value if it is the case.

However, no default return value has been implemented in the function, and this has an undefined behavior. For instance, what happens if the coordinates are outside of the mesh? This has lead to problems in my local tomography use case, where the function returned mainly an index zero for receivers situated outside of my defined mesh.

I added a negative return value to fix this. In the rest of the code, negative indexes are skipped, so this addition complies with the use of the code.